### PR TITLE
Specify left set in bipartite matching algorithm.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
 python:
-  - "3.2"
-  - "3.3"
-  - "3.4"
+  - 3.6
 script: python setup.py test

--- a/birkhoff.py
+++ b/birkhoff.py
@@ -202,7 +202,13 @@ def birkhoff_von_neumann_decomposition(D):
         # Compute a perfect matching for this graph. The dictionary `M` has one
         # entry for each matched vertex (in both the left and the right vertex
         # sets), and the corresponding value is its partner.
-        M = maximum_matching(G)
+        #
+        # The bipartite maximum matching algorithm requires specifying
+        # the left set of nodes in the bipartite graph. By construction,
+        # the left set of nodes is {0, ..., n - 1} and the right set is
+        # {n, ..., 2n - 1}; see `to_bipartite_matrix()`.
+        left_nodes = range(n)
+        M = maximum_matching(G, left_nodes)
         # However, since we have both a left vertex set and a right vertex set,
         # each representing the original vertex set of the pattern graph
         # (``W``), we need to convert any vertex greater than ``n`` to its

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy
-networkx
+networkx>=2.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@
 from setuptools import setup
 
 #: Installation requirements.
-requirements = ['numpy', 'networkx>=1.10']
+requirements = ['numpy', 'networkx>=2.0']
 
 
 setup(


### PR DESCRIPTION
Fixes issue #3.

*What problem does this solve?*
This updates the call to the bipartite maximum matching algorithm in NetworkX to add a required argument (the left set of nodes) that appeared in version 2.0. This updates `setup.py` and `requirements.txt` to reflect the minimum version 2.0 of NetworkX required for this new code.

*How does this affect the user?*
This increases the minimum NetworkX version.

*Why is this better than the alternative?*
An alternative is to require a version of NetworkX less than 2.0, but this code change was easy enough to implement.